### PR TITLE
ManageNotifications component is now gated behind feature flag.

### DIFF
--- a/packages/web/src/components/admin/manage-user.vue
+++ b/packages/web/src/components/admin/manage-user.vue
@@ -29,7 +29,7 @@
           "
         />
 
-        <ManageNotifications :user="user" />
+        <ManageNotifications v-if="notificationsEnabled.value" :user="user" />
       </div>
     </div>
   </TabsPanel>
@@ -42,10 +42,12 @@ import {
   UserRole,
   UserSettingsDTO,
 } from '@bottomtime/api';
+import { NotificationsFeature } from '@bottomtime/common';
 
 import { ref } from 'vue';
 
 import { TabInfo } from '../../common';
+import { useFeature } from '../../featrues';
 import TabsPanel from '../common/tabs-panel.vue';
 import EditProfile from '../users/edit-profile.vue';
 import EditSettings from '../users/edit-settings.vue';
@@ -61,6 +63,8 @@ const Tabs: TabInfo[] = [
   { key: 'profile', label: 'Profile' },
   { key: 'settings', label: 'Settings' },
 ];
+
+const notificationsEnabled = useFeature(NotificationsFeature);
 const activeTab = ref(Tabs[0].key);
 const editProfileTab = ref<InstanceType<typeof EditProfile> | null>(null);
 

--- a/packages/web/src/views/users/settings-view.vue
+++ b/packages/web/src/views/users/settings-view.vue
@@ -11,7 +11,7 @@
           />
         </FormBox>
 
-        <FormBox>
+        <FormBox v-if="notificationsEnabled.value">
           <ManageNotifications
             v-if="currentUser.user"
             :user="currentUser.user"
@@ -24,15 +24,18 @@
 
 <script setup lang="ts">
 import { UserSettingsDTO } from '@bottomtime/api';
+import { NotificationsFeature } from '@bottomtime/common';
 
 import FormBox from '../../components/common/form-box.vue';
 import PageTitle from '../../components/common/page-title.vue';
 import RequireAuth from '../../components/common/require-auth.vue';
 import EditSettings from '../../components/users/edit-settings.vue';
 import ManageNotifications from '../../components/users/manage-notifications.vue';
+import { useFeature } from '../../featrues';
 import { useCurrentUser } from '../../store';
 
 const currentUser = useCurrentUser();
+const notificationsEnabled = useFeature(NotificationsFeature);
 
 function onSave(settings: UserSettingsDTO) {
   if (currentUser.user) {

--- a/packages/web/tests/spec/components/admin/manage-user.spec.ts
+++ b/packages/web/tests/spec/components/admin/manage-user.spec.ts
@@ -1,25 +1,42 @@
 import { UserDTO, UserRole } from '@bottomtime/api';
+import { NotificationsFeature } from '@bottomtime/common';
 
 import { ComponentMountingOptions, shallowMount } from '@vue/test-utils';
+
+import { Pinia, createPinia } from 'pinia';
 
 import AdminManageUser from '../../../../src/components/admin/manage-user.vue';
 import FormBox from '../../../../src/components/common/form-box.vue';
 import TabsPanel from '../../../../src/components/common/tabs-panel.vue';
 import EditProfile from '../../../../src/components/users/edit-profile.vue';
+import { FeaturesServiceKey } from '../../../../src/featrues';
+import { ConfigCatClientMock } from '../../../config-cat-client-mock';
 import { BasicUser } from '../../../fixtures/users';
 import MockEditProfile from '../../../stubs/edit-profile.stub.vue';
 import MockEditSettings from '../../../stubs/edit-settings.stub.vue';
 import MockManageUserAccount from '../../../stubs/manage-user-account.stub.vue';
 
 describe('Admin Manage User component', () => {
+  let pinia: Pinia;
   let userData: UserDTO;
   let opts: ComponentMountingOptions<typeof AdminManageUser>;
+  let features: ConfigCatClientMock;
+
+  beforeAll(() => {
+    features = new ConfigCatClientMock();
+  });
 
   beforeEach(() => {
+    pinia = createPinia();
+    features.flags[NotificationsFeature.key] = true;
     userData = { ...BasicUser };
     opts = {
       props: { user: userData },
       global: {
+        plugins: [pinia],
+        provide: {
+          [FeaturesServiceKey as symbol]: features,
+        },
         stubs: {
           EditProfile: MockEditProfile,
           EditSettings: MockEditSettings,

--- a/packages/web/tests/spec/components/admin/users-list.spec.ts
+++ b/packages/web/tests/spec/components/admin/users-list.spec.ts
@@ -7,6 +7,7 @@ import {
   UserRole,
   UsersSortBy,
 } from '@bottomtime/api';
+import { NotificationsFeature } from '@bottomtime/common';
 
 import {
   ComponentMountingOptions,
@@ -24,6 +25,8 @@ import { ApiClientKey } from '../../../../src/api-client';
 import ManageUser from '../../../../src/components/admin/manage-user.vue';
 import UsersListItem from '../../../../src/components/admin/users-list-item.vue';
 import UsersList from '../../../../src/components/admin/users-list.vue';
+import { FeaturesServiceKey } from '../../../../src/featrues';
+import { ConfigCatClientMock } from '../../../config-cat-client-mock';
 import { createRouter } from '../../../fixtures/create-router';
 import SearchResults from '../../../fixtures/user-search-results.json';
 
@@ -42,6 +45,7 @@ describe('Users List component', () => {
   let fetcher: Fetcher;
   let client: ApiClient;
   let router: Router;
+  let features: ConfigCatClientMock;
   let searchResults: ApiList<UserDTO>;
 
   let pinia: Pinia;
@@ -51,6 +55,7 @@ describe('Users List component', () => {
     fetcher = new Fetcher();
     client = new ApiClient({ fetcher });
     router = createRouter();
+    features = new ConfigCatClientMock();
   });
 
   beforeEach(() => {
@@ -59,12 +64,15 @@ describe('Users List component', () => {
       totalCount: SearchResults.totalCount,
     };
 
+    features.flags[NotificationsFeature.key] = true;
+
     pinia = createPinia();
     opts = {
       global: {
         plugins: [pinia, router],
         provide: {
           [ApiClientKey as symbol]: client,
+          [FeaturesServiceKey as symbol]: features,
         },
         stubs: { teleport: true },
       },

--- a/packages/web/tests/spec/views/admin/user-view.spec.ts
+++ b/packages/web/tests/spec/views/admin/user-view.spec.ts
@@ -1,5 +1,6 @@
 import { Fetcher, UserDTO, UserRole } from '@bottomtime/api';
 import { ApiClient, User } from '@bottomtime/api';
+import { NotificationsFeature } from '@bottomtime/common';
 
 import {
   ComponentMountingOptions,
@@ -15,8 +16,10 @@ import { Router } from 'vue-router';
 
 import { ApiClientKey } from '../../../../src/api-client';
 import ManageUser from '../../../../src/components/admin/manage-user.vue';
+import { FeaturesServiceKey } from '../../../../src/featrues';
 import { useCurrentUser } from '../../../../src/store';
 import AdminUserView from '../../../../src/views/admin/user-view.vue';
+import { ConfigCatClientMock } from '../../../config-cat-client-mock';
 import { createHttpError } from '../../../fixtures/create-http-error';
 import { createRouter } from '../../../fixtures/create-router';
 import {
@@ -32,6 +35,7 @@ describe('Account View', () => {
   let fetcher: Fetcher;
   let client: ApiClient;
   let router: Router;
+  let features: ConfigCatClientMock;
 
   let pinia: Pinia;
   let currentUser: ReturnType<typeof useCurrentUser>;
@@ -49,16 +53,19 @@ describe('Account View', () => {
         component: ManageUser,
       },
     ]);
+    features = new ConfigCatClientMock();
   });
 
   beforeEach(async () => {
     pinia = createPinia();
     currentUser = useCurrentUser(pinia);
+    features.flags[NotificationsFeature.key] = true;
     opts = {
       global: {
         plugins: [pinia, router],
         provide: {
           [ApiClientKey as symbol]: client,
+          [FeaturesServiceKey as symbol]: features,
         },
         stubs: {
           teleport: true,

--- a/packages/web/tests/spec/views/users/settings-view.spec.ts
+++ b/packages/web/tests/spec/views/users/settings-view.spec.ts
@@ -6,22 +6,30 @@ import {
   WeightUnit,
 } from '@bottomtime/api';
 import { ApiClient } from '@bottomtime/api';
+import { NotificationsFeature } from '@bottomtime/common';
 
-import { ComponentMountingOptions, mount } from '@vue/test-utils';
+import {
+  ComponentMountingOptions,
+  flushPromises,
+  mount,
+} from '@vue/test-utils';
 
 import { Pinia, createPinia } from 'pinia';
 import { Router } from 'vue-router';
 
 import { ApiClientKey } from '../../../../src/api-client';
 import EditSettings from '../../../../src/components/users/edit-settings.vue';
+import { FeaturesServiceKey } from '../../../../src/featrues';
 import { useCurrentUser } from '../../../../src/store';
 import SettingsView from '../../../../src/views/users/settings-view.vue';
+import { ConfigCatClientMock } from '../../../config-cat-client-mock';
 import { createRouter } from '../../../fixtures/create-router';
 import { BasicUser } from '../../../fixtures/users';
 
 describe('Settings View', () => {
   let client: ApiClient;
   let router: Router;
+  let features: ConfigCatClientMock;
 
   let pinia: Pinia;
   let opts: ComponentMountingOptions<typeof SettingsView>;
@@ -29,15 +37,18 @@ describe('Settings View', () => {
   beforeAll(() => {
     client = new ApiClient();
     router = createRouter();
+    features = new ConfigCatClientMock();
   });
 
   beforeEach(() => {
     pinia = createPinia();
+    features.flags[NotificationsFeature.key] = true;
     opts = {
       global: {
         plugins: [pinia, router],
         provide: {
           [ApiClientKey as symbol]: client,
+          [FeaturesServiceKey as symbol]: features,
         },
         stubs: {
           teleport: true,
@@ -46,10 +57,11 @@ describe('Settings View', () => {
     };
   });
 
-  it('will display the login form if user is unauthenticated', () => {
+  it('will display the login form if user is unauthenticated', async () => {
     const currentUser = useCurrentUser(pinia);
     currentUser.user = null;
     const wrapper = mount(SettingsView, opts);
+    await flushPromises();
     expect(
       wrapper.get('[data-testid="require-auth-anonymous"]').isVisible(),
     ).toBe(true);


### PR DESCRIPTION
This pull request introduces a feature flag for managing notifications in the admin and user settings views. The changes include conditional rendering based on the feature flag and updates to the test cases to support the new feature.

Key changes:

### Feature Implementation:
* Added `NotificationsFeature` import and `useFeature` hook to manage the feature flag for notifications in `packages/web/src/components/admin/manage-user.vue`. [[1]](diffhunk://#diff-901926f4b0092e01ea163abf215e30fda1b1b72cb47d8d52b378095ff50ed0feR45-R50) [[2]](diffhunk://#diff-901926f4b0092e01ea163abf215e30fda1b1b72cb47d8d52b378095ff50ed0feR66-R67)
* Conditional rendering of `ManageNotifications` component based on the `notificationsEnabled` feature flag in `packages/web/src/components/admin/manage-user.vue` and `packages/web/src/views/users/settings-view.vue`. [[1]](diffhunk://#diff-901926f4b0092e01ea163abf215e30fda1b1b72cb47d8d52b378095ff50ed0feL32-R32) [[2]](diffhunk://#diff-0d79001a7dc7697f1dff59ecaa2eb9af32bf05455b6c59949603587771706225L14-R14)

### Test Updates:
* Updated test cases to include the `NotificationsFeature` and mock its behavior using `ConfigCatClientMock` in multiple test files (`manage-user.spec.ts`, `users-list.spec.ts`, `user-view.spec.ts`, `settings-view.spec.ts`). [[1]](diffhunk://#diff-e010c7bac408b2caea728eec4e9a0ebe19078961ad7e4d5381c41e29eaae817aR2-R39) [[2]](diffhunk://#diff-a9f03e7bf459ea58a45df151b15871b9a89a2738bca81d13ce7f55c8da88ebb7R10) [[3]](diffhunk://#diff-dcc05ebde22d02006589d2a7bd250886b8712bb21a0c93ce1058d4d3b8cdf6a8R3) [[4]](diffhunk://#diff-0b86e7f9fed705585dea4f331372af1b7a4f99cf79d86b4e2860f71f4e80dc80R9-R51)
* Added feature flag setup in test configurations to ensure tests run with the notifications feature enabled. [[1]](diffhunk://#diff-e010c7bac408b2caea728eec4e9a0ebe19078961ad7e4d5381c41e29eaae817aR2-R39) [[2]](diffhunk://#diff-a9f03e7bf459ea58a45df151b15871b9a89a2738bca81d13ce7f55c8da88ebb7R48) [[3]](diffhunk://#diff-dcc05ebde22d02006589d2a7bd250886b8712bb21a0c93ce1058d4d3b8cdf6a8R38) [[4]](diffhunk://#diff-0b86e7f9fed705585dea4f331372af1b7a4f99cf79d86b4e2860f71f4e80dc80L49-R64)