### PR TITLE
Attempting to shard web tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,7 +275,9 @@ jobs:
           root: ./
           paths:
             - packages/web/coverage/
-            - web-$CIRCLE_NODE_INDEX.coverage.json
+            - web-0.coverage.json
+            - web-1.coverage.json
+            - web-2.coverage.json
 
   test_e2e:
     docker:


### PR DESCRIPTION
This pull request includes several changes to the `.circleci/config.yml` file to improve the efficiency and accuracy of test execution and coverage reporting. The changes primarily focus on parallelizing the test runs and adjusting the coverage reporting process.

Improvements to test execution and coverage reporting:

* Increased the `parallelism` value to 3 to enable parallel test execution.
* Modified the test command to include sharding, allowing tests to be distributed across multiple nodes.
* Adjusted the coverage output file names to include the node index, ensuring unique filenames for each node.
* Updated the coverage report command to account for the increased number of parallel nodes, changing the `-p` parameter value from 5 to 7.