### PR TITLE
Updating to Node.js v22.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  aws-cli: circleci/aws-cli@5.1.1
+  aws-cli: circleci/aws-cli@5.1.2
   terraform: circleci/terraform@3.5.0
 
 commands:
@@ -93,7 +93,7 @@ commands:
 jobs:
   build:
     docker:
-      - image: cimg/node:20.14
+      - image: cimg/node:22.13
     resource_class: medium+
     environment:
       NODE_ENV: production # Build for production for minified bundles
@@ -135,7 +135,7 @@ jobs:
 
   test_packages:
     docker:
-      - image: cimg/node:20.14
+      - image: cimg/node:22.13
     resource_class: medium
     environment:
       JEST_JUNIT_OUTPUT_DIR: ./reports/
@@ -195,7 +195,7 @@ jobs:
 
   test_service:
     docker:
-      - image: cimg/node:20.14
+      - image: cimg/node:22.13
       - image: postgis/postgis:14-3.4-alpine
         environment:
           POSTGRES_DB: postgres
@@ -245,7 +245,7 @@ jobs:
 
   test_web:
     docker:
-      - image: cimg/node:20.14-browsers
+      - image: cimg/node:22.13-browsers
     environment:
       JEST_JUNIT_OUTPUT_DIR: ./reports/
       NODE_OPTIONS: '--max-old-space-size=8192'
@@ -282,7 +282,7 @@ jobs:
 
   test_e2e:
     docker:
-      - image: cimg/node:20.14-browsers
+      - image: cimg/node:22.13-browsers
     resource_class: medium
     environment:
       BT_POSTGRES_REQUIRE_SSL: 'true'
@@ -304,7 +304,7 @@ jobs:
 
   report_coverage:
     docker:
-      - image: cimg/node:20.14
+      - image: cimg/node:22.13
     resource_class: medium
     steps:
       - attach_workspace:
@@ -329,7 +329,7 @@ jobs:
 
   deploy_e2e:
     docker:
-      - image: cimg/node:20.14
+      - image: cimg/node:22.13
     environment:
       BT_POSTGRES_REQUIRE_SSL: 'true'
     resource_class: medium
@@ -351,7 +351,7 @@ jobs:
 
   deploy_staging:
     docker:
-      - image: cimg/node:20.14
+      - image: cimg/node:22.13
     environment:
       BT_POSTGRES_REQUIRE_SSL: 'true'
     resource_class: medium
@@ -372,7 +372,7 @@ jobs:
 
   deploy_production:
     docker:
-      - image: cimg/node:20.14
+      - image: cimg/node:22.13
     environment:
       BT_POSTGRES_REQUIRE_SSL: 'true'
     resource_class: medium

--- a/Dockerfile.service
+++ b/Dockerfile.service
@@ -1,5 +1,5 @@
 # Base image running AWS Lambda Runtime Interface Client (RIC)
-FROM public.ecr.aws/lambda/nodejs:20 AS base
+FROM public.ecr.aws/lambda/nodejs:22 AS base
 RUN corepack enable
 
 FROM base AS build

--- a/README.md
+++ b/README.md
@@ -28,17 +28,17 @@ It will make installing the other dependencies much easier.
 
 ### Node.js
 
-You'll need the [Node.js](https://nodejs.org/en) runtime to run the platform. The platform is currently built on Node v20.
+You'll need the [Node.js](https://nodejs.org/en) runtime to run the platform. The platform is currently built on Node v22.
 
 It is recommended that you use Node Version Manager ([NVM](https://github.com/nvm-sh/nvm#readme)) to manage your
 Node installations. It will allow you to have multiple versions of Node.js installed at once and easily switch
 between them.
 
-Once NVM is installed, you can simply run the following to install and activate Node.js v20.x
+Once NVM is installed, you can simply run the following to install and activate Node.js v22.x
 
 ```bash
-nvm install 20
-nvm use 20
+nvm install 22
+nvm use 22
 ```
 
 ### Yarn
@@ -190,7 +190,7 @@ The containers each expose one or more ports on your `localhost` that you can us
 When it comes time to upgrade to a newer version of Node.js updates will need to be made in the following places:
 
 - Update any instructions here in this and any other README.md files.
-- Update the CircleCI config file at `.circleci/config.yml`. Update all references to Node Docker images so that the project is being built on the correct version. Try to be precise with your version number. (I.e. `20.14` instead of just `20`).
+- Update the CircleCI config file at `.circleci/config.yml`. Update all references to Node Docker images so that the project is being built on the correct version. Try to be precise with your version number. (I.e. `22.13` instead of just `22`).
 - Update the Dockerfiles (`Dockerfile.*`) in the project root - ensure that they are being built with images using the correct version of Node.js.
 - Don't forget to upgrade your own local Node.js runtime: `nvm install <version> && nvm use <version>`
 

--- a/init-localstack.sh
+++ b/init-localstack.sh
@@ -2,3 +2,4 @@
 
 awslocal s3api create-bucket --bucket media
 awslocal sqs create-queue --queue-name email
+awslocal sqs create-queue --queue-name reviews

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -87,7 +87,7 @@ resource "aws_lambda_function" "email_service" {
 
   description = "BottomTime Email Service Lambda Function"
   handler     = "service/sls.handler"
-  runtime     = "nodejs20.x"
+  runtime     = "nodejs22.x"
   timeout     = 30
   memory_size = 256
 
@@ -142,7 +142,7 @@ resource "aws_lambda_function" "keepalive" {
 
   description = "BottomTime Keep-Alive Lambda Function"
   handler     = "index.handler"
-  runtime     = "nodejs20.x"
+  runtime     = "nodejs22.x"
   timeout     = 60
 
   logging_config {


### PR DESCRIPTION
This pull request includes several updates to upgrade the Node.js version from 20 to 22 across various files and configurations. The changes ensure that the project is built and run using the latest Node.js version.

### Node.js Version Upgrade:

* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L96-R96): Updated the Node.js Docker image version from `20.14` to `22.13` across multiple jobs. [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L96-R96) [[2]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L138-R138) [[3]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L198-R198) [[4]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L248-R248) [[5]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L285-R285) [[6]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L307-R307) [[7]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L332-R332) [[8]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L354-R354) [[9]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L375-R375)
* [`Dockerfile.service`](diffhunk://#diff-bf20ab3538b5a513fc4ad507d35f57acb2a2eb8120f462a3d326342b98617810L2-R2): Updated the base image from `public.ecr.aws/lambda/nodejs:20` to `public.ecr.aws/lambda/nodejs:22`.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R41): Updated references to Node.js version from v20 to v22 and corresponding installation instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R41) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L193-R193)
* [`terraform/lambda.tf`](diffhunk://#diff-63b9e08c8fd20e5cd26c81ae80216d00316fd0d2cf48f356416b02be4b5cfa9cL90-R90): Updated the `runtime` for AWS Lambda functions from `nodejs20.x` to `nodejs22.x`. [[1]](diffhunk://#diff-63b9e08c8fd20e5cd26c81ae80216d00316fd0d2cf48f356416b02be4b5cfa9cL90-R90) [[2]](diffhunk://#diff-63b9e08c8fd20e5cd26c81ae80216d00316fd0d2cf48f356416b02be4b5cfa9cL145-R145)

### Additional Changes:

* [`init-localstack.sh`](diffhunk://#diff-04162ce272dfb61ea123a9a84aefa8df862e3c5e1fa38ceeb914bfdbf490cea6R5): Added a new SQS queue named `reviews`.